### PR TITLE
Fix typos in notebook comments

### DIFF
--- a/.ipynb_checkpoints/Search by term-checkpoint.ipynb
+++ b/.ipynb_checkpoints/Search by term-checkpoint.ipynb
@@ -54,7 +54,7 @@
     }
    ],
    "source": [
-    "#search tearm to check. no commas!\n",
+    "#search term to check (no commas!)\n",
     "q = input('Enter your search term: ')\n",
     "encoded_q = request.quote(q)"
    ]

--- a/Search by term.ipynb
+++ b/Search by term.ipynb
@@ -54,7 +54,7 @@
     }
    ],
    "source": [
-    "#search tearm to check. no commas!\n",
+    "#search term to check (no commas!)\n",
     "q = input('Enter your search term: ')\n",
     "encoded_q = request.quote(q)"
    ]


### PR DESCRIPTION
## Summary
- update the search term comment in both notebooks

## Testing
- `jq '.' 'Search by term.ipynb'`
- `jq '.' .ipynb_checkpoints/'Search by term-checkpoint.ipynb'`


------
https://chatgpt.com/codex/tasks/task_e_6844f42a4dd483208371d0f3f2c98fa9