### PR TITLE
Add YouTube API utility and tests

### DIFF
--- a/tests/fixtures/sample_search.json
+++ b/tests/fixtures/sample_search.json
@@ -1,0 +1,24 @@
+{
+  "kind": "youtube#searchListResponse",
+  "etag": "etag",
+  "nextPageToken": "CAEQAA",
+  "regionCode": "US",
+  "pageInfo": {
+    "totalResults": 2,
+    "resultsPerPage": 2
+  },
+  "items": [
+    {
+      "kind": "youtube#searchResult",
+      "etag": "etag1",
+      "id": {"kind": "youtube#video", "videoId": "id1"},
+      "snippet": {"title": "First Video"}
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "etag2",
+      "id": {"kind": "youtube#video", "videoId": "id2"},
+      "snippet": {"title": "Second Video"}
+    }
+  ]
+}

--- a/tests/test_get_titles.py
+++ b/tests/test_get_titles.py
@@ -1,0 +1,24 @@
+import json
+import unittest
+
+from youtube_api import get_titles
+
+
+class TestGetTitles(unittest.TestCase):
+    def setUp(self):
+        with open('tests/fixtures/sample_search.json', 'r', encoding='utf-8') as f:
+            self.sample = json.load(f)
+
+    def test_returns_titles(self):
+        expected = ['first video', 'second video']
+        self.assertEqual(get_titles(self.sample), expected)
+
+    def test_missing_next_page_token(self):
+        data = dict(self.sample)
+        data.pop('nextPageToken', None)
+        expected = ['first video', 'second video']
+        self.assertEqual(get_titles(data), expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/youtube_api.py
+++ b/youtube_api.py
@@ -1,0 +1,31 @@
+"""Utility functions for working with YouTube API responses."""
+from typing import List, Dict, Any
+
+
+def get_titles(response: Dict[str, Any]) -> List[str]:
+    """Return a list of lowercase video titles from a search response.
+
+    Parameters
+    ----------
+    response : dict
+        Dictionary representing a YouTube search API response.
+
+    Returns
+    -------
+    list of str
+        Titles converted to lowercase. Missing ``nextPageToken`` keys are
+        ignored gracefully.
+    """
+    # Ensure ``items`` key exists
+    items = response.get("items", [])
+    titles = []
+    for item in items:
+        snippet = item.get("snippet", {})
+        title = snippet.get("title")
+        if title is not None:
+            titles.append(title.lower())
+
+    # Access ``nextPageToken`` with ``get`` so it doesn't raise ``KeyError``
+    _ = response.get("nextPageToken")
+
+    return titles


### PR DESCRIPTION
## Summary
- implement standalone `get_titles` in `youtube_api.py`
- add sample search fixture and unit tests

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_6844f46249cc8320b8c754f124e74fdf